### PR TITLE
fix paths with no trailing slash

### DIFF
--- a/fs2json.py
+++ b/fs2json.py
@@ -48,7 +48,8 @@ def main():
 
     args = args.parse_args()
 
-    path = args.path
+    path = os.path.normpath(args.path)
+    path = path + "/"
     exclude = args.exclude or []
     exclude = [os.path.join("/", os.path.normpath(p)) for p in exclude]
     exclude = set(exclude)


### PR DESCRIPTION
paths with trailing slashes and without should be treated the same, but they are not. paths without trailing slashes have the directory given as a top-level directory.
